### PR TITLE
Correção do link You Don't Know JS: Scope & Closures [Book]

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Todas as traduções para este repositório serão listadas abaixo:
 
 ### Artigos (inglês)
 
- * 📜 [You Don't Know JS: Scope & Closures [Book] — Kyle Simpson](https://github.com/getify/You-Dont-Know-JS/blob/master/scope%20%26%20closures/ch3.md)
+ * 📜 [You Don't Know JS: Scope & Closures [Book] — Kyle Simpson](https://github.com/getify/You-Dont-Know-JS/blob/1st-ed/scope%20%26%20closures/ch3.md)
  * 📜 [The battle between Function Scope and Block Scope — Marius Herring](http://www.deadcoderising.com/2017-04-11-es6-var-let-and-const-the-battle-between-function-scope-and-block-scope/)
  * 📜 [Emulating Block Scope in JavaScript — Josh Clanton](http://adripofjavascript.com/blog/drips/emulating-block-scope-in-javascript.html)
  * 📜 [The Difference Between Function and Block Scope in JavaScript — Joseph Cardillo](https://medium.com/@josephcardillo/the-difference-between-function-and-block-scope-in-javascript-4296b2322abe)


### PR DESCRIPTION
O novo link aponta para a branch da primeira edição. A nova edição está em progresso e por isso os capítulos não estão mais disponíveis na branch master.